### PR TITLE
feat: add setting to adjust industry efficiency modifier

### DIFF
--- a/NoTeleporting/Mod.cs
+++ b/NoTeleporting/Mod.cs
@@ -32,6 +32,7 @@ namespace NoTeleporting
                 updateSystem.UpdateAt<PatchedResourceBuyerSystem>(SystemUpdatePhase.GameSimulation);
                 updateSystem.UpdateAt<PatchedCompanyInitializeSystem>(SystemUpdatePhase.Modification5);
                 updateSystem.UpdateAt<PatchedResourcesInitializeSystem>(SystemUpdatePhase.Modification5);
+                updateSystem.UpdateAt<IndustrialProcessingEffeciencySystem>(SystemUpdatePhase.ModificationEnd);
             }
             catch (System.Exception e)
             {
@@ -62,6 +63,10 @@ namespace NoTeleporting
                 PatchedCompanyInitializeSystem.StartingOutputResourceAmount = m_Setting.ProcessorStartingOutputResourceAmount;
                 PatchedCompanyInitializeSystem.StartingServiceResourceAmount = m_Setting.ServiceStartingResourceAmount;
                 PatchedResourcesInitializeSystem.ServiceBuildingStartingResourcePercentage = 0.01f * m_Setting.ServiceBuildingStartingResourcePercentage;
+
+                IndustrialProcessingEffeciencySystem.IndustrialEfficiencyModifierPercentage = 0.01f * m_Setting.ProcessorEffeciencyFactorAmount;
+                updateSystem.World.GetExistingSystemManaged<IndustrialProcessingEffeciencySystem>().Enabled = true;
+                updateSystem.World.GetExistingSystemManaged<IndustrialProcessingEffeciencySystem>().Update();
                 log.Debug($"Finished applying settings");
             }
 

--- a/NoTeleporting/Setting.cs
+++ b/NoTeleporting/Setting.cs
@@ -32,6 +32,10 @@ namespace NoTeleporting
         [SettingsUISection(kSection, kProcessorSettings)]
         public int ProcessorStartingOutputResourceAmount { get; set; }
 
+        [SettingsUISlider(min = 10, max = 500, step = 1, scalarMultiplier = 1, unit = Unit.kPercentage )]
+        [SettingsUISection(kSection, kProcessorSettings)]
+        public int ProcessorEffeciencyFactorAmount { get; set; }
+
         [SettingsUISlider(min = 0, max = 10000, step = 100, scalarMultiplier = 1, unit = Unit.kWeight)]
         [SettingsUISection(kSection, kServiceCompanies)]
         public int ServiceStartingResourceAmount { get; set; }
@@ -44,6 +48,7 @@ namespace NoTeleporting
         {
             ProcessorStartingResourceAmount = 0;
             ProcessorStartingOutputResourceAmount = 1000;
+            ProcessorEffeciencyFactorAmount = 100;
             ServiceStartingResourceAmount = 0;
             ServiceBuildingStartingResourcePercentage = 100;
         }
@@ -70,6 +75,14 @@ namespace NoTeleporting
 
                 { m_Setting.GetOptionLabelLocaleID(nameof(Setting.ProcessorStartingOutputResourceAmount)), "Starting output resource amount" },
                 { m_Setting.GetOptionDescLocaleID(nameof(Setting.ProcessorStartingOutputResourceAmount)), "The vanilla value is 1 t." },
+
+                { m_Setting.GetOptionLabelLocaleID(nameof(Setting.ProcessorEffeciencyFactorAmount)), "Industry efficiency amount" },
+                { m_Setting.GetOptionDescLocaleID(nameof(Setting.ProcessorEffeciencyFactorAmount)), "This adjusts the industrial efficiency of your entire city. The vanilla value is 100%." +
+                "\n" +
+                "Increasing this value will likely:  1) Speed up production of input resources into output resources. 2) Increase industry profits. 3) Increase traffic to/from industry. 4) Lower demand for industry relative to other zoning types." +
+                "\n" +
+                "For example: setting this to 300% will cause all Industry (that processes resources) to convert input resources to output resources 3 times faster."
+                },
 
                 { m_Setting.GetOptionGroupLocaleID(Setting.kServiceCompanies), "Commercial companies" },
 

--- a/NoTeleporting/Systems/IndustrialProcessingEffeciencySystem.cs
+++ b/NoTeleporting/Systems/IndustrialProcessingEffeciencySystem.cs
@@ -1,0 +1,95 @@
+﻿using Colossal.Logging;
+using Game;
+using Game.Common;
+using Game.Prefabs;
+using Game.Tools;
+using System;
+using Unity.Entities;
+using System.Runtime.CompilerServices;
+
+namespace LeanBusinesses.Systems
+{
+    internal partial class IndustrialProcessingEffeciencySystem : GameSystemBase
+    {
+        public static float IndustrialEfficiencyModifierPercentage = 1f;
+
+        // The system default is 2f as of patch 1.11.1f1
+        private static float IndustrialEfficiencyFactorVanilla = 2f;
+
+        private EntityQuery __economyQuery;
+        private ILog _log;
+
+        protected override void OnCreate()
+        {
+            base.OnCreate();
+            _log = NoTeleporting.Mod.log;
+
+            RequireForUpdate<EconomyParameterData>();
+        }
+
+        protected override void OnCreateForCompiler()
+        {
+            base.OnCreateForCompiler();
+            __AssignQueries(ref base.CheckedStateRef);
+        }
+
+        protected override void OnUpdate()
+        {
+            AdjustEconomyParameterData();
+
+            // Prevents accidental looping if system update phase is changed.
+            Enabled = false;
+        }
+
+        public void AdjustEconomyParameterData()
+        {
+            try
+            {
+                _log.Info($"{nameof(IndustrialProcessingEffeciencySystem)}.{nameof(AdjustEconomyParameterData)} Running");
+                int entityCount = __economyQuery.CalculateEntityCount();
+                if (entityCount != 1)
+                {
+                    _log.Error($"{nameof(IndustrialProcessingEffeciencySystem)}.{nameof(AdjustEconomyParameterData)} Entity query returned {entityCount} entities; can't continue since we require exactly 1 singleton entity");
+                    return;
+                }
+                EconomyParameterData componentData = __economyQuery.GetSingleton<EconomyParameterData>();
+                Entity economy = __economyQuery.GetSingletonEntity();
+
+                float newIndustrialEfficiencyValue = IndustrialEfficiencyModifierPercentage * IndustrialEfficiencyFactorVanilla;
+                if (componentData.m_IndustrialEfficiency != newIndustrialEfficiencyValue)
+                {
+                    _log.Info($"{nameof(IndustrialProcessingEffeciencySystem)}.{nameof(AdjustEconomyParameterData)} Attempting to set m_IndustrialEfficiency parameter to {newIndustrialEfficiencyValue} (originally {componentData.m_IndustrialEfficiency})");
+                    componentData.m_IndustrialEfficiency = newIndustrialEfficiencyValue;
+                    EntityManager.SetComponentData(economy, componentData);
+                }
+                else
+                {
+                    _log.Info($"{nameof(IndustrialProcessingEffeciencySystem)}.{nameof(AdjustEconomyParameterData)} Skipping; m_IndustrialEfficiency parameter is already set to the correct value");
+                }
+
+                _log.Info($"{nameof(IndustrialProcessingEffeciencySystem)}.{nameof(AdjustEconomyParameterData)} Finished");
+
+            }
+            catch (Exception e)
+            {
+                _log.Error($"Failed to set Industrial Effeciency adjustment in EconomyParameterData");
+                _log.Error(e.Message);
+                _log.Error(e.StackTrace);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void __AssignQueries(ref SystemState state)
+        {
+            __economyQuery = state.GetEntityQuery(new EntityQueryDesc
+            {
+                All = new ComponentType[1] { ComponentType.ReadWrite<EconomyParameterData>() },
+                Any = new ComponentType[0],
+                None = new ComponentType[2] { ComponentType.ReadOnly<Deleted>(), ComponentType.ReadOnly<Temp>() },
+                Disabled = new ComponentType[0],
+                Absent = new ComponentType[0],
+                Options = EntityQueryOptions.IncludeSystems
+            });
+        }
+    }
+}


### PR DESCRIPTION
Since your mod already touches industry resource modifiers, I figured this would be best to centralize into your mod. More than happy to keep this into something separate - I know this branches further away from being a simple "no teleport" mod.

Changes:

- Adds a UI slider to adjust the entire city's industry efficiency modifier. I set as a percentage from 10% to 500%.
- Adds a new system which doesn't do any patching. Instead, it takes the singleton `EconomyParameters` prefab and adjusts the economy-wide `industrialEfficiency` coefficient. I thought this was safer instead of patching the entire _ProcessingCompanySystem_ logic.

I primarily added this feature because it seems like industry processing was nerfed in the economy 2.0 update and I wanted to adjust the efficiency to make it more challenging either on the financial side or traffic side.